### PR TITLE
Refine contact page presentation

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,6 +17,13 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Libre+Franklin:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
   </head>
   <body>
     <Header />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,8 +5,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="Contact | Mark Baldwin-Smith" description="Reach out for collaboration, prayer requests, or speaking opportunities.">
   <h1>Contact</h1>
   <p class="lead">
-    I am open to invitations for teaching, consulting, collaborative writing, and prayer partnerships. Share a note below
-    and I will respond as soon as possible.
+    I am open to invitations for teaching, consulting, collaborative writing, and prayer partnerships. Reach out by
+    email or connect on social, and I will respond as soon as possible.
   </p>
 
   <section class="contact-card surface surface--tinted">
@@ -14,9 +14,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <p>
       <strong>Email:</strong>
       <a href="mailto:mb110413@gmail.com">mb110413@gmail.com</a>
-    </p>
-    <p>
-      <strong>Newsletter:</strong> Subscribe to receive monthly updates with new prayers, poems, and resources.
     </p>
     <p class="social-intro">Prefer to connect on social?</p>
     <ul class="social-links" aria-label="Social media">
@@ -28,28 +25,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           rel="noopener noreferrer"
           aria-label="GitHub"
         >
-          <span class="icon-box">
-            <svg class="social-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <title>GitHub</title>
-              <path
-                d="M7.4 6 9.4 3.8c.3-.35.9-.12.9.32V6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M16.6 6 14.6 3.8c-.3-.35-.9-.12-.9.32V6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <circle cx="12" cy="13" r="6.5" fill="none" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="10" cy="12.5" r="1.1" fill="currentColor" />
-              <circle cx="14" cy="12.5" r="1.1" fill="currentColor" />
-              <path d="M9.2 16.2c1.2 1 2.4 1 3.6 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.5" />
-            </svg>
+          <span class="icon-box" aria-hidden="true">
+            <i class="social-icon fa-brands fa-github"></i>
           </span>
           <span>GitHub</span>
         </a>
@@ -62,13 +39,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           rel="noopener noreferrer"
           aria-label="Instagram"
         >
-          <span class="icon-box">
-            <svg class="social-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <title>Instagram</title>
-              <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="12" cy="12" r="4.2" fill="none" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="17" cy="7" r="1.3" fill="currentColor" />
-            </svg>
+          <span class="icon-box" aria-hidden="true">
+            <i class="social-icon fa-brands fa-instagram"></i>
           </span>
           <span>Instagram</span>
         </a>
@@ -81,14 +53,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           rel="noopener noreferrer"
           aria-label="X"
         >
-          <span class="icon-box">
-            <svg class="social-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <title>X</title>
-              <path
-                d="M5 4h3.4l3.8 5.7L16 4h3l-5.2 7.2L21 20h-3.4l-4-5.9L9 20H6l5.3-7.6Z"
-                fill="currentColor"
-              />
-            </svg>
+          <span class="icon-box" aria-hidden="true">
+            <i class="social-icon fa-brands fa-x-twitter"></i>
           </span>
           <span>X</span>
         </a>
@@ -101,14 +67,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           rel="noopener noreferrer"
           aria-label="LinkedIn"
         >
-          <span class="icon-box">
-            <svg class="social-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <title>LinkedIn</title>
-              <rect x="3" y="3" width="18" height="18" rx="3" fill="none" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="8.5" cy="9" r="1.3" fill="currentColor" />
-              <path d="M7.4 11.3h2.2v7H7.4z" fill="currentColor" />
-              <path d="M12.3 11.3h2.1v1c.6-.8 1.4-1.2 2.4-1.2 1.8 0 3.5 1.1 3.5 3.7V18h-2.2v-3.2c0-1.1-.5-1.8-1.5-1.8-.9 0-1.4.5-1.6 1.1V18h-2.2Z" fill="currentColor" />
-            </svg>
+          <span class="icon-box" aria-hidden="true">
+            <i class="social-icon fa-brands fa-linkedin"></i>
           </span>
           <span>LinkedIn</span>
         </a>
@@ -121,14 +81,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           rel="noopener noreferrer"
           aria-label="Threads"
         >
-          <span class="icon-box">
-            <svg class="social-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-              <title>Threads</title>
-              <path
-                d="M12 4.5c4.3 0 7.5 2.2 7.5 5.8 0 2.6-1.4 4.5-3.8 5.4-.3 2.2-1.9 3.8-4.7 3.8-2.6 0-4.6-1.7-4.6-4.4 0-2.6 1.8-4.1 4.4-4.1 1.4 0 2.4.4 3.1 1.1-.1-.7-.4-1.2-.9-1.6-.6-.4-1.2-.6-2.3-.7l.1-1.6c1.4.1 2.5.5 3.2 1.1.8.6 1.3 1.4 1.6 2.4.2.5.2.9.2 1.4 0 .5-.1 1-.2 1.4-.3 1.3-1.4 2.3-2.8 2.3-1.4 0-2.4-1-2.4-2.2 0-1.3.8-2.1 1.9-2.1.6 0 1 .2 1.2.4.2.2.4.5.4.9 0 .2-.1.5-.2.7 0 .2-.1.3-.1.4 0 .2.2.4.5.4.4 0 .7-.3.9-.8.2-.5.3-.9.3-1.4 0-2.1-1.8-3.4-4.3-3.4-2.7 0-4.6 1.7-4.6 4.4 0 2.9 2.1 4.6 4.9 4.6 1.8 0 3.2-.9 3.7-2.3l1.5.6C16.3 18.7 14.4 20 12 20c-3.6 0-6.5-2.5-6.5-6.2C5.5 7.8 8.6 4.5 12 4.5Z"
-                fill="currentColor"
-              />
-            </svg>
+          <span class="icon-box" aria-hidden="true">
+            <i class="social-icon fa-brands fa-threads"></i>
           </span>
           <span>Threads</span>
         </a>
@@ -136,29 +90,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </ul>
   </section>
 
-  <section class="form surface">
-    <h2>Send a message</h2>
-    <p>
-      This static form includes the prompts I use to guide conversations. Integrate your preferred form service or email
-      automation when you are ready to collect responses.
-    </p>
-
-    <form>
-      <label>
-        Name
-        <input type="text" name="name" placeholder="Your name" required />
-      </label>
-      <label>
-        Email
-        <input type="email" name="email" placeholder="you@email.com" required />
-      </label>
-      <label>
-        Message
-        <textarea name="message" rows="6" placeholder="How can I support you?" required></textarea>
-      </label>
-      <button type="submit" disabled>Submit (disabled in demo)</button>
-    </form>
-  </section>
 </BaseLayout>
 
 <style>
@@ -168,8 +99,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     line-height: 1.8;
   }
 
-  .contact-card,
-  .form {
+  .contact-card {
     margin-top: 2.5rem;
     display: grid;
     gap: 1.25rem;
@@ -215,8 +145,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   }
 
   .social-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 1.4rem;
     height: 1.4rem;
+    font-size: 1.4rem;
   }
 
   .social-link:hover,
@@ -229,38 +163,5 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .social-link:focus-visible .icon-box {
     background: linear-gradient(135deg, rgba(138, 90, 60, 0.15), rgba(94, 60, 40, 0.3));
     color: var(--accent-dark);
-  }
-
-  form {
-    display: grid;
-    gap: 1.5rem;
-    margin-top: 1.5rem;
-  }
-
-  label {
-    display: grid;
-    gap: 0.5rem;
-    font-weight: 600;
-  }
-
-  input,
-  textarea {
-    font: inherit;
-    padding: 0.75rem 1rem;
-    border-radius: 0.85rem;
-    border: 1px solid rgba(92, 73, 58, 0.26);
-    background: rgba(249, 241, 229, 0.55);
-  }
-
-  button {
-    justify-self: flex-start;
-    padding: 0.75rem 1.6rem;
-    border-radius: 999px;
-    border: none;
-    font-weight: 600;
-    background: linear-gradient(135deg, rgba(138, 90, 60, 0.18), rgba(94, 60, 40, 0.3));
-    color: var(--accent-dark);
-    cursor: not-allowed;
-    opacity: 0.65;
   }
 </style>


### PR DESCRIPTION
## Summary
- remove the newsletter blurb from the contact page and rely on social connections instead
- load Font Awesome globally so the contact page can use brand icons
- swap custom SVGs on the contact page for Font Awesome brand icons while keeping the existing styling
- remove the inactive "Send a message" form section so the page focuses on direct contact options

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d44dbb57148330a623923a02218e54