### PR TITLE
Use favicon JPEG for site and header branding

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,7 +12,10 @@ const navLinks = [
 
 <header class="site-header">
   <div class="container">
-    <a class="brand" href="/">Mark Baldwin-Smith</a>
+    <a class="brand" href="/">
+      <img class="brand__icon" src="/favicon.jpeg" alt="Mark Baldwin-Smith icon" width="48" height="48" loading="lazy" />
+      Mark Baldwin-Smith
+    </a>
     <nav aria-label="Primary navigation">
       <ul>
         {navLinks.map((link) => (
@@ -60,13 +63,14 @@ const navLinks = [
     gap: 0.65rem;
   }
 
-  .brand::before {
-    content: '';
+  .brand__icon {
     width: 2.4rem;
     height: 2.4rem;
     border-radius: 50%;
     border: 1px solid rgba(255, 255, 255, 0.2);
-    background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0));
+    object-fit: cover;
+    display: block;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.38);
   }
 
   nav ul {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="icon" type="image/jpeg" href="/favicon.jpeg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
- add the `favicon.jpeg` asset as the site favicon so browsers display the intended image
- replace the decorative header circle with the favicon image to match the updated branding

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d45037932083309cf4521d90c2dee3