### PR TITLE
Enhance home page aesthetics

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -49,6 +49,10 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     --shadow-sm: 0 18px 36px -32px rgba(42, 31, 22, 0.55);
   }
 
+  :global(html) {
+    scroll-behavior: smooth;
+  }
+
   :global(body) {
     margin: 0;
     font-family: 'Source Serif 4', Georgia, 'Times New Roman', serif;
@@ -61,6 +65,28 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     line-height: 1.7;
     font-feature-settings: 'liga' 1, 'clig' 1, 'kern' 1;
     background-attachment: fixed;
+    position: relative;
+  }
+
+  :global(body)::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 20% 18%, rgba(255, 237, 214, 0.55), transparent 55%),
+      radial-gradient(circle at 82% 12%, rgba(207, 178, 150, 0.35), transparent 60%),
+      radial-gradient(circle at 16% 78%, rgba(188, 209, 202, 0.28), transparent 55%),
+      repeating-linear-gradient(
+        125deg,
+        rgba(138, 90, 60, 0.07) 0,
+        rgba(138, 90, 60, 0.07) 1px,
+        rgba(255, 255, 255, 0) 1px,
+        rgba(255, 255, 255, 0) 10px
+      );
+    mix-blend-mode: soft-light;
+    opacity: 0.55;
+    z-index: 0;
   }
 
   :global(main.page) {
@@ -141,11 +167,31 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     border-radius: 1.5rem;
     box-shadow: var(--shadow-sm);
     padding: clamp(1.75rem, 3vw, 2.75rem);
+    position: relative;
+    overflow: hidden;
+  }
+
+  :global(.surface::after) {
+    content: '';
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 247, 234, 0));
+    opacity: 0.45;
+    mix-blend-mode: soft-light;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  :global(.surface > *) {
+    position: relative;
+    z-index: 1;
   }
 
   :global(.surface--tinted) {
     background: rgba(255, 255, 255, 0.8);
     border: 1px solid rgba(92, 73, 58, 0.12);
+    backdrop-filter: blur(18px);
   }
 
   :global(.kicker) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,12 +95,75 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     text-align: left;
     display: grid;
     gap: clamp(1.5rem, 3vw, 2.75rem);
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+  }
+
+  .hero::before,
+  .hero::after {
+    content: '';
+    position: absolute;
+    width: clamp(18rem, 35vw, 28rem);
+    height: clamp(18rem, 38vw, 32rem);
+    border-radius: 999px;
+    filter: blur(0.5rem);
+    opacity: 0.65;
+    z-index: 0;
+    pointer-events: none;
+    animation: drift 26s ease-in-out infinite;
+  }
+
+  .hero::before {
+    top: clamp(-6rem, -8vw, -3rem);
+    right: clamp(-5rem, -6vw, -2rem);
+    background: radial-gradient(circle at 30% 30%, rgba(255, 202, 152, 0.6), transparent 70%);
+  }
+
+  .hero::after {
+    bottom: clamp(-7rem, -10vw, -4rem);
+    left: clamp(-4rem, -6vw, -1rem);
+    background: radial-gradient(circle at 60% 60%, rgba(157, 187, 178, 0.45), transparent 65%);
+    animation-delay: -12s;
+  }
+
+  .hero > * {
+    position: relative;
+    z-index: 1;
   }
 
   .lead {
     font-size: 1.15rem;
     line-height: 1.85;
     color: rgba(36, 28, 21, 0.88);
+    max-width: 64ch;
+    position: relative;
+  }
+
+  .lead::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, rgba(255, 239, 224, 0.7), rgba(255, 255, 255, 0));
+    opacity: 0.55;
+    border-radius: 1rem;
+    z-index: -1;
+    pointer-events: none;
+  }
+
+  .hero h1 {
+    position: relative;
+  }
+
+  .hero h1::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -0.45rem;
+    width: clamp(7rem, 45%, 12rem);
+    height: 3px;
+    background: linear-gradient(90deg, rgba(138, 90, 60, 0.8), rgba(255, 255, 255, 0));
+    border-radius: 999px;
   }
 
   .hero-meta {
@@ -109,6 +172,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
     border-top: 1px solid rgba(92, 73, 58, 0.15);
     padding-top: clamp(1.5rem, 3vw, 2.5rem);
+    position: relative;
+  }
+
+  .hero-meta::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: -1px;
+    width: 100%;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(138, 90, 60, 0.35), rgba(255, 255, 255, 0));
   }
 
   .hero-meta h2 {
@@ -119,10 +193,29 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .collections {
     display: grid;
     gap: clamp(2rem, 4vw, 3rem);
+    position: relative;
   }
 
   .collections__intro p {
     color: rgba(36, 28, 21, 0.75);
+  }
+
+  .collections__intro h2 {
+    position: relative;
+    display: inline-block;
+    padding-bottom: 0.4rem;
+  }
+
+  .collections__intro h2::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, rgba(138, 90, 60, 0.9), rgba(255, 255, 255, 0));
+    border-radius: 999px;
+    opacity: 0.65;
   }
 
   .grid {
@@ -134,6 +227,32 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .collection-card {
     display: grid;
     gap: 1.1rem;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+    border: 1px solid rgba(92, 73, 58, 0.18);
+  }
+
+  .collection-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.65), rgba(255, 244, 231, 0));
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .collection-card:hover,
+  .collection-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: 0 22px 34px -24px rgba(36, 28, 21, 0.6);
+    border-color: rgba(138, 90, 60, 0.3);
+  }
+
+  .collection-card:hover::before,
+  .collection-card:focus-within::before {
+    opacity: 1;
   }
 
   .collection-card h3 {
@@ -148,9 +267,27 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     justify-self: start;
   }
 
+  @keyframes drift {
+    0% {
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+
+    50% {
+      transform: translate3d(1.5rem, -1.5rem, 0) scale(1.05);
+    }
+
+    100% {
+      transform: translate3d(-1.25rem, 1.75rem, 0) scale(0.95);
+    }
+  }
+
   @media (max-width: 600px) {
     .hero {
       text-align: left;
+    }
+
+    .hero h1::after {
+      width: clamp(6rem, 80%, 10rem);
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- enrich the global aesthetic with parchment-inspired overlays, smoother scrolling, and glowing surface treatments
- add ambient gradient orbs, typographic accents, and lead-in highlight to the hero section for a more luminous welcome
- introduce interactive collection cards and section underline flourishes to the library grid for tactile feedback

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d457929d148330961494ddcd36b008