### PR TITLE
Enhance site navigation, sharing metadata, and contact options

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,6 +8,16 @@ const navLinks = [
   { href: '/portfolio', label: 'Portfolio' },
   { href: '/contact', label: 'Contact' },
 ];
+
+const trimmedPath = Astro.url.pathname.replace(/\/+$/, '') || '/';
+const isActive = (href: string) => {
+  if (href === '/') {
+    return trimmedPath === '/';
+  }
+
+  const normalized = href.replace(/\/+$/, '');
+  return trimmedPath === normalized;
+};
 ---
 
 <header class="site-header">
@@ -20,7 +30,13 @@ const navLinks = [
       <ul>
         {navLinks.map((link) => (
           <li>
-            <a href={link.href}>{link.label}</a>
+            <a
+              href={link.href}
+              aria-current={isActive(link.href) ? 'page' : undefined}
+              class:list={{ 'nav-link': true, 'nav-link--active': isActive(link.href) }}
+            >
+              {link.label}
+            </a>
           </li>
         ))}
       </ul>
@@ -82,7 +98,7 @@ const navLinks = [
     padding: 0;
   }
 
-  nav a {
+  .nav-link {
     color: rgba(255, 255, 255, 0.82);
     text-decoration: none;
     font-family: 'Libre Franklin', 'Source Serif 4', serif;
@@ -96,7 +112,7 @@ const navLinks = [
     transition: color 0.2s ease;
   }
 
-  nav a::after {
+  .nav-link::after {
     content: '';
     position: absolute;
     left: 0;
@@ -109,14 +125,19 @@ const navLinks = [
     transition: transform 0.25s ease;
   }
 
-  nav a:hover,
-  nav a:focus-visible {
+  .nav-link:hover,
+  .nav-link:focus-visible {
     color: #ffffff;
   }
 
-  nav a:hover::after,
-  nav a:focus-visible::after {
+  .nav-link:hover::after,
+  .nav-link:focus-visible::after,
+  .nav-link--active::after {
     transform: scaleX(1);
+  }
+
+  .nav-link--active {
+    color: #ffffff;
   }
 
   @media (max-width: 720px) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,7 +2,13 @@
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 
-const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, prayers, and creative work.' } = Astro.props;
+const {
+  title = 'Mark Baldwin-Smith',
+  description = 'Personal reflections, prayers, and creative work.',
+} = Astro.props;
+const currentURL = Astro.url;
+const canonicalURL = Astro.site ? new URL(currentURL.pathname, Astro.site) : currentURL;
+const ogImageURL = Astro.site ? new URL('/favicon.jpeg', Astro.site).href : '/favicon.jpeg';
 ---
 
 <html lang="en">
@@ -11,6 +17,17 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalURL.href} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL.href} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImageURL} />
+    <meta property="og:site_name" content="Mark Baldwin-Smith" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageURL} />
     <link rel="icon" type="image/jpeg" href="/favicon.jpeg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,8 +44,9 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
     />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <Header />
-    <main class="page">
+    <main id="main-content" class="page">
       <slot />
     </main>
     <Footer />
@@ -154,6 +172,30 @@ const { title = 'Mark Baldwin-Smith', description = 'Personal reflections, praye
   :global(a:focus-visible) {
     color: var(--accent);
     border-color: rgba(138, 90, 60, 0.5);
+  }
+
+  .skip-link {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    clip-path: inset(0 round 999px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 999;
+  }
+
+  .skip-link:focus {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   :global(::selection) {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -126,6 +126,54 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </ul>
     </article>
 
+    <article class="surface contact-direct">
+      <div class="contact-direct__intro">
+        <h2>Write me directly</h2>
+        <p>
+          Prefer a private note? Use the address below or send a message through the form. I review each submission personally
+          and respond as promptly as I’m able.
+        </p>
+        <a class="contact-direct__email" href="mailto:mb110413@gmail.com">
+          <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+          mb110413@gmail.com
+        </a>
+      </div>
+      <form
+        class="contact-form"
+        action="https://formsubmit.co/mb110413@gmail.com"
+        method="POST"
+        aria-label="Send a message to Mark Baldwin-Smith"
+      >
+        <input type="hidden" name="_captcha" value="false" />
+        <label class="contact-form__field">
+          <span>Name</span>
+          <input type="text" name="name" required autocomplete="name" />
+        </label>
+        <label class="contact-form__field">
+          <span>Email</span>
+          <input type="email" name="email" required autocomplete="email" />
+        </label>
+        <label class="contact-form__field">
+          <span>How can I help?</span>
+          <select name="reason" required>
+            <option value="">Select an option</option>
+            <option value="prayer">Prayer request</option>
+            <option value="collaboration">Collaboration</option>
+            <option value="speaking">Speaking inquiry</option>
+            <option value="other">Something else</option>
+          </select>
+        </label>
+        <label class="contact-form__field contact-form__field--textarea">
+          <span>Message</span>
+          <textarea name="message" rows="5" required></textarea>
+        </label>
+        <button class="button" type="submit">
+          <i class="fa-solid fa-paper-plane" aria-hidden="true"></i>
+          Send message
+        </button>
+      </form>
+    </article>
+
     <aside class="surface surface--tinted contact-blessing">
       <h2>Prayer before correspondence</h2>
       <p>
@@ -160,6 +208,81 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .contact-card {
     display: grid;
     gap: clamp(1.75rem, 3vw, 2.5rem);
+  }
+
+  .contact-direct {
+    display: grid;
+    gap: 1.5rem;
+    border: 1px solid rgba(92, 73, 58, 0.16);
+  }
+
+  .contact-direct__intro {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .contact-direct__email {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-weight: 600;
+    color: var(--accent-dark);
+    border: none;
+  }
+
+  .contact-direct__email i {
+    font-size: 1rem;
+  }
+
+  .contact-form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .contact-form__field {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .contact-form__field span {
+    font-family: 'Libre Franklin', 'Source Serif 4', serif;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: rgba(36, 28, 21, 0.68);
+  }
+
+  .contact-form input,
+  .contact-form select,
+  .contact-form textarea {
+    border-radius: 0.85rem;
+    border: 1px solid rgba(92, 73, 58, 0.18);
+    padding: 0.75rem 1rem;
+    font: inherit;
+    background: rgba(255, 255, 255, 0.75);
+    color: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .contact-form input:focus,
+  .contact-form select:focus,
+  .contact-form textarea:focus {
+    outline: none;
+    border-color: rgba(138, 90, 60, 0.4);
+    box-shadow: 0 0 0 3px rgba(138, 90, 60, 0.18);
+  }
+
+  .contact-form__field--textarea textarea {
+    resize: vertical;
+    min-height: 8rem;
+  }
+
+  .contact-form .button {
+    justify-self: start;
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
   }
 
   .contact-card__intro {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,59 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
   </section>
 
+  <section class="home-latest page-section">
+    <div class="home-latest__intro surface">
+      <p class="kicker">Recently added</p>
+      <h2>Fresh words for your visit</h2>
+      <p>
+        Returners often ask what is new. These highlights gather the most recent pieces across the library so you can dive in
+        without hunting room to room.
+      </p>
+    </div>
+    <div class="home-latest__grid">
+      <article class="surface home-latest__card">
+        <h3>
+          <a href="/prayers#a-bold-prayer">A Bold Prayer</a>
+        </h3>
+        <p>
+          A wholehearted petition for courage and consecrated devotion, ready to be prayed aloud with friends who need strength
+          for the road ahead.
+        </p>
+        <footer>
+          <span class="meta-chip"><i class="fa-solid fa-flame" aria-hidden="true"></i> Consecration</span>
+          <span class="meta-chip"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Protection</span>
+        </footer>
+      </article>
+
+      <article class="surface home-latest__card">
+        <h3>
+          <a href="/musings#plato-to-paraclete">Cosmos to Comforter</a>
+        </h3>
+        <p>
+          Travel with me from philosophical abstraction to the living Christ&mdash;a testimony that threads contemplation into
+          relationship.
+        </p>
+        <footer>
+          <span class="meta-chip"><i class="fa-solid fa-route" aria-hidden="true"></i> Journey</span>
+          <span class="meta-chip"><i class="fa-solid fa-star" aria-hidden="true"></i> Wonder</span>
+        </footer>
+      </article>
+
+      <article class="surface home-latest__card">
+        <h3>
+          <a href="/poetry">Poetic notebooks</a>
+        </h3>
+        <p>
+          A growing cycle of poems tracing seasons of faith, crafted to slow the heart and widen your sense of the holy in daily
+          life.
+        </p>
+        <footer>
+          <span class="meta-chip"><i class="fa-solid fa-feather" aria-hidden="true"></i> Poetry</span>
+        </footer>
+      </article>
+    </div>
+  </section>
+
   <section class="home-collections page-section">
     <article class="surface surface--tinted home-collections__intro">
       <p class="kicker">The Library</p>
@@ -130,6 +183,56 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   .home-collections {
     display: grid;
     gap: clamp(2.25rem, 4vw, 3.5rem);
+  }
+
+  .home-latest {
+    display: grid;
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+  }
+
+  .home-latest__intro {
+    display: grid;
+    gap: 0.85rem;
+    border: 1px solid rgba(92, 73, 58, 0.16);
+  }
+
+  .home-latest__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  }
+
+  .home-latest__card {
+    display: grid;
+    gap: 0.75rem;
+    border: 1px solid rgba(92, 73, 58, 0.16);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  }
+
+  .home-latest__card:hover,
+  .home-latest__card:focus-within {
+    transform: translateY(-4px);
+    border-color: rgba(138, 90, 60, 0.3);
+    box-shadow: 0 18px 26px -22px rgba(36, 28, 21, 0.45);
+  }
+
+  .home-latest__card h3 {
+    margin: 0;
+  }
+
+  .home-latest__card p {
+    color: rgba(36, 28, 21, 0.78);
+  }
+
+  .home-latest__card footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .home-latest__card a {
+    border: none;
   }
 
   .home-collections__intro {

--- a/src/pages/musings.astro
+++ b/src/pages/musings.astro
@@ -35,18 +35,36 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </div>
       </header>
       <div class="essay">
-        <p>Throughout my teens and twenties, I was an arch-atheist, perhaps even an anti-theist. I didn’t just not believe in God, I hated the very idea of Him. I thought His followers were deluded hypocrites clinging to their Sky-Daddy as an existential comfort blanket. I knew better!</p>
-        <p>Fast forward a few years, I’m now working for a Christian church, pray multiple times a day, and attend as many Bible study and discipleship groups as I can find! Here’s an account of how I made this journey.</p>
-        <p>The first big step on my journey to Theism was deep meditation and contemplation. My experiences on the liminal boundaries of consciousness made me question Materialism. I came to an understanding that, rather than everything boiling down to mere “stuff” or matter; consciousness or mind was the basic substrate of reality. I was already in contact with Zen Buddhism and the ancient Western philosophies of Neoplatonism and Stoicism, which really clicked for me once I shed the Materialist mindset.</p>
-        <h3>Plato to Paraclete</h3>
-        <p>On the eve of my conversion, I believed in a kind of non-Theist trinity. Firstly, the Source, the hypothetical first cause, which I accepted must exist on philosophical grounds but which I would not concede was a person or God. Secondly, the Logos-Sophia, or Word-Wisdom, which I accepted from the Greek and Hellenistic Jewish traditions as the aspect of reality that makes the Universe intelligible, tangible, and coherent: again, not a person, but more like a force or Dao. Thirdly, the Presence, a deeply benevolent disembodied consciousness that I’d experienced in the depths of contemplative meditation: this one, I was most tempted to concede was a person, but I was on the fence. These Three I’d later come to know as the Father, the Son, and the Holy Spirit but, up until this point, I was still missing a relationship with the Divine Persons.</p>
-        <p>Familiar with the Logos or Word from Greek philosophy, I discovered that St. John had co-opted this concept in his Gospel account (John 1). Like any good Neoplatonist, I couldn’t stand the thought of the perfect, perhaps even spiritual, realm of pure forms crossing over into our crude, base, world of physical matter. Outraged, I set out to read the Gospel According to John, to disprove, once and for all, that the “Word became flesh” (John 1:14). The Jesus I encountered blew me away. Simultaneously breath-takingly powerful and majestic, yet tragically meek and heroically humble to the point of death and willing to go to any lengths, even death on a cross, to serve those He loves. This wasn’t the Jesus of the student Christian Union, who was a kind of watered-down wise man or Western Buddha in sandals, but a radical King from beyond staging a revolution to seize back control of His Creation, to topple a corrupt seemingly victorious usurper, and to grant eternal life to all those who would call Him Lord of their hearts.</p>
-        <h3>Finding Paradise</h3>
-        <p>I had a lot to make sense of, so I went on a long walk. I was living in a little thatched cottage near a Paradise Garden called Stourhead, belonging to the National Trust. On this walk, I experienced something I’d been chasing as a Buddhist for a long time: satori, or a sudden realisation of enlightenment. Out of nowhere, my first instinct was to raise my hands, eyes, and voice to heaven and say “thank you, Lord Jesus”! That was it, something burst within in me, and a sensation like running water coursed through my body, electrifying every cell. For the first time in my life, I was fully awake, and aware of God’s presence. I just kept saying, over and over: “You’re real, I can see You!”. My elation was short-lived, because I was suddenly overcome with intense conviction, a realisation that there was in fact a spiritual war raging within and around me and, not only was I not as neutral as I thought, I was actively serving the forces of evil. I found a bench and wept, begging Jesus to forgive me and take me into His Kingdom, pledging to Him what little I could offer.</p>
-        <blockquote>In Zen Buddhism, there is a tradition of writing a poem when one reaches enlightenment. So, as a Zen practitioner at the time, I wrote a poem to commemorate my enlightenment in Christ and to regale the story.</blockquote>
-        <h3>Washed Clean</h3>
-        <p>Having gone to a Church of England primary school, my logical next step seemed to be to go to an Anglican Church. While they were initially unsure of what to do with a fervent adult convert, I was eventually baptised in a swimming pool on an Anglican worship retreat in Devon. I’ve meandered from church to church, and denomination to denomination, but throughout it all God has been good and remained steadfast in His love. I now work for a church in Cambridge, help lead the Sunday post-service prayer team, and get involved in all kinds of Christian retreats and Bible study groups. I have a special love for evangelism, particularly to Muslims and Atheists.</p>
-        <p>The big change in my conversion was moving from grasping with my intellect, to having a heartfelt relationship with my Creator. While reason has its place, I believe that it is through His relational quality that God is best known and revealed. The subject of my worship went from being the cosmos to being the Comforter Who created and sustains the cosmos. To my surprise, my restless quest for self-knowledge was fulfilled when, in knowing Him, I came to truly know and love myself.</p>
+        <nav class="essay__toc" aria-label="In-page navigation">
+          <h3 class="essay__toc-title">Jump to a chapter</h3>
+          <ol>
+            <li><a href="#introduction">From skeptic to seeker</a></li>
+            <li><a href="#plato-to-paraclete">Plato to Paraclete</a></li>
+            <li><a href="#finding-paradise">Finding Paradise</a></li>
+            <li><a href="#washed-clean">Washed Clean</a></li>
+          </ol>
+        </nav>
+        <section class="essay-section" id="introduction">
+          <h3>From skeptic to seeker</h3>
+          <p>Throughout my teens and twenties, I was an arch-atheist, perhaps even an anti-theist. I didn’t just not believe in God, I hated the very idea of Him. I thought His followers were deluded hypocrites clinging to their Sky-Daddy as an existential comfort blanket. I knew better!</p>
+          <p>Fast forward a few years, I’m now working for a Christian church, pray multiple times a day, and attend as many Bible study and discipleship groups as I can find! Here’s an account of how I made this journey.</p>
+          <p>The first big step on my journey to Theism was deep meditation and contemplation. My experiences on the liminal boundaries of consciousness made me question Materialism. I came to an understanding that, rather than everything boiling down to mere “stuff” or matter; consciousness or mind was the basic substrate of reality. I was already in contact with Zen Buddhism and the ancient Western philosophies of Neoplatonism and Stoicism, which really clicked for me once I shed the Materialist mindset.</p>
+        </section>
+        <section class="essay-section" id="plato-to-paraclete">
+          <h3>Plato to Paraclete</h3>
+          <p>On the eve of my conversion, I believed in a kind of non-Theist trinity. Firstly, the Source, the hypothetical first cause, which I accepted must exist on philosophical grounds but which I would not concede was a person or God. Secondly, the Logos-Sophia, or Word-Wisdom, which I accepted from the Greek and Hellenistic Jewish traditions as the aspect of reality that makes the Universe intelligible, tangible, and coherent: again, not a person, but more like a force or Dao. Thirdly, the Presence, a deeply benevolent disembodied consciousness that I’d experienced in the depths of contemplative meditation: this one, I was most tempted to concede was a person, but I was on the fence. These Three I’d later come to know as the Father, the Son, and the Holy Spirit but, up until this point, I was still missing a relationship with the Divine Persons.</p>
+          <p>Familiar with the Logos or Word from Greek philosophy, I discovered that St. John had co-opted this concept in his Gospel account (John 1). Like any good Neoplatonist, I couldn’t stand the thought of the perfect, perhaps even spiritual, realm of pure forms crossing over into our crude, base, world of physical matter. Outraged, I set out to read the Gospel According to John, to disprove, once and for all, that the “Word became flesh” (John 1:14). The Jesus I encountered blew me away. Simultaneously breath-takingly powerful and majestic, yet tragically meek and heroically humble to the point of death and willing to go to any lengths, even death on a cross, to serve those He loves. This wasn’t the Jesus of the student Christian Union, who was a kind of watered-down wise man or Western Buddha in sandals, but a radical King from beyond staging a revolution to seize back control of His Creation, to topple a corrupt seemingly victorious usurper, and to grant eternal life to all those who would call Him Lord of their hearts.</p>
+        </section>
+        <section class="essay-section" id="finding-paradise">
+          <h3>Finding Paradise</h3>
+          <p>I had a lot to make sense of, so I went on a long walk. I was living in a little thatched cottage near a Paradise Garden called Stourhead, belonging to the National Trust. On this walk, I experienced something I’d been chasing as a Buddhist for a long time: satori, or a sudden realisation of enlightenment. Out of nowhere, my first instinct was to raise my hands, eyes, and voice to heaven and say “thank you, Lord Jesus”! That was it, something burst within in me, and a sensation like running water coursed through my body, electrifying every cell. For the first time in my life, I was fully awake, and aware of God’s presence. I just kept saying, over and over: “You’re real, I can see You!”. My elation was short-lived, because I was suddenly overcome with intense conviction, a realisation that there was in fact a spiritual war raging within and around me and, not only was I not as neutral as I thought, I was actively serving the forces of evil. I found a bench and wept, begging Jesus to forgive me and take me into His Kingdom, pledging to Him what little I could offer.</p>
+          <blockquote>In Zen Buddhism, there is a tradition of writing a poem when one reaches enlightenment. So, as a Zen practitioner at the time, I wrote a poem to commemorate my enlightenment in Christ and to regale the story.</blockquote>
+        </section>
+        <section class="essay-section" id="washed-clean">
+          <h3>Washed Clean</h3>
+          <p>Having gone to a Church of England primary school, my logical next step seemed to be to go to an Anglican Church. While they were initially unsure of what to do with a fervent adult convert, I was eventually baptised in a swimming pool on an Anglican worship retreat in Devon. I’ve meandered from church to church, and denomination to denomination, but throughout it all God has been good and remained steadfast in His love. I now work for a church in Cambridge, help lead the Sunday post-service prayer team, and get involved in all kinds of Christian retreats and Bible study groups. I have a special love for evangelism, particularly to Muslims and Atheists.</p>
+          <p>The big change in my conversion was moving from grasping with my intellect, to having a heartfelt relationship with my Creator. While reason has its place, I believe that it is through His relational quality that God is best known and revealed. The subject of my worship went from being the cosmos to being the Comforter Who created and sustains the cosmos. To my surprise, my restless quest for self-knowledge was fulfilled when, in knowing Him, I came to truly know and love myself.</p>
+        </section>
       </div>
     </article>
 
@@ -122,12 +140,48 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   .essay {
     display: grid;
-    gap: 1.5rem;
+    gap: clamp(1.5rem, 3vw, 2rem);
     color: rgba(36, 28, 21, 0.82);
   }
 
-  .essay h3 {
-    margin-bottom: -0.5rem;
+  .essay__toc {
+    padding: 1.5rem;
+    border-radius: 1.2rem;
+    border: 1px solid rgba(92, 73, 58, 0.18);
+    background: rgba(255, 255, 255, 0.6);
+    display: grid;
+    gap: 1rem;
+  }
+
+  .essay__toc-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-family: 'Libre Franklin', 'Source Serif 4', serif;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(36, 28, 21, 0.7);
+  }
+
+  .essay__toc ol {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.4rem;
+  }
+
+  .essay__toc a {
+    color: var(--accent-dark);
+    border-bottom: 1px solid rgba(138, 90, 60, 0.28);
+    padding-bottom: 0.15em;
+  }
+
+  .essay-section {
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  .essay-section h3 {
+    margin: 0;
   }
 
   .musings__notes {

--- a/src/pages/prayers.astro
+++ b/src/pages/prayers.astro
@@ -27,7 +27,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <article class="surface prayer-card">
       <header class="prayer-card__header">
         <div class="accent-divider" aria-hidden="true"></div>
-        <h2>A Bold Prayer</h2>
+        <h2 id="a-bold-prayer">A Bold Prayer</h2>
         <p class="subtitle">For steadfast courage and wholehearted devotion.</p>
         <div class="prayer-card__meta">
           <span class="floating-badge"><i class="fa-solid fa-flame" aria-hidden="true"></i>Consecration</span>


### PR DESCRIPTION
## Summary
- add canonical, Open Graph, and Twitter metadata plus a global skip link for improved accessibility and sharing
- highlight recent writing on the home page and add in-page navigation to the long-form musings feature
- surface a direct email address and contact form while improving navigation state awareness site-wide

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d53eefe184833099b9ded96494f84a