### PR TITLE
Enhance header nav link styling

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -181,10 +181,12 @@ const isActive = (href: string) => {
     letter-spacing: 0.08em;
     text-transform: uppercase;
     font-size: 0.75rem;
-    border: none;
-    padding-bottom: 0;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    padding-block: 0.4rem;
+    padding-inline: 0.85rem;
     position: relative;
-    transition: color 0.2s ease;
+    transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
   }
 
   .nav-link::after {
@@ -203,6 +205,8 @@ const isActive = (href: string) => {
   .nav-link:hover,
   .nav-link:focus-visible {
     color: #ffffff;
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.22);
   }
 
   .nav-link:hover::after,
@@ -213,6 +217,8 @@ const isActive = (href: string) => {
 
   .nav-link--active {
     color: #ffffff;
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.32);
   }
 
   .sr-only {


### PR DESCRIPTION
## Summary
- add pill-shaped styling to header navigation links with background transitions
- highlight active and hovered navigation items with semi-opaque accent fill and border treatment

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f50a7d5f94833088f8e480009751d8