### PR TITLE
Add accent footer glow to base layout background

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -103,6 +103,7 @@ const jsonLd = {
     background:
       radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.72) 0, rgba(255, 255, 255, 0) 38%),
       radial-gradient(circle at 82% 12%, rgba(255, 255, 255, 0.65) 0, rgba(255, 255, 255, 0) 36%),
+      radial-gradient(ellipse at 50% 118%, rgba(138, 90, 60, 0.15) 0, rgba(138, 90, 60, 0) 62%),
       linear-gradient(180deg, var(--background) 0%, var(--background-alt) 100%);
     min-height: 100vh;
     line-height: 1.7;
@@ -131,6 +132,7 @@ const jsonLd = {
       radial-gradient(circle at 20% 18%, rgba(255, 237, 214, 0.55), transparent 55%),
       radial-gradient(circle at 82% 12%, rgba(207, 178, 150, 0.35), transparent 60%),
       radial-gradient(circle at 16% 78%, rgba(188, 209, 202, 0.28), transparent 55%),
+      radial-gradient(ellipse at 50% 124%, rgba(138, 90, 60, 0.18), transparent 68%),
       repeating-linear-gradient(
         125deg,
         rgba(138, 90, 60, 0.07) 0,


### PR DESCRIPTION
## Summary
- add a low-opacity accent radial gradient near the footer in the base layout background
- extend the body overlay with a complementary gradient to preserve the layered glow effect

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f50a8089548330ab5f79c27a9e93ce