### PR TITLE
Add subtle accent glow to header icon

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -114,7 +114,10 @@ const isActive = (href: string) => {
     border: 1px solid rgba(255, 255, 255, 0.2);
     object-fit: cover;
     display: block;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.38);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.38),
+      0 0 0.35rem rgba(138, 90, 60, 0.45),
+      0 0 0.85rem rgba(94, 60, 40, 0.28);
   }
 
   .nav-toggle {


### PR DESCRIPTION
## Summary
- enhance the header brand icon shadow with accent-coloured glow layers to create a soft halo effect that follows the circular icon

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f50a7a05948330bd350cff1bd63828