### PR TITLE
Update branding and highlight author identity

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,8 +21,8 @@ const isActive = (href: string) => {
   <div class="container">
     <div class="header-bar">
       <a class="brand" href="/">
-        <img class="brand__icon" src="/favicon.jpeg" alt="Mark Baldwin-Smith icon" width="48" height="48" loading="lazy" />
-        Mark Baldwin-Smith
+        <img class="brand__icon" src="/favicon.jpeg" alt="Kerygma Academy icon" width="48" height="48" loading="lazy" />
+        Kerygma Academy
       </a>
       <button
         type="button"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,9 +20,9 @@ const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site) : new URL('
       <p class="kicker">About</p>
       <h1>Called to hold faith and craft together</h1>
       <p class="lead">
-        I am a pilgrim of words, symbols, and sacrament&mdash;walking a path where poetry, prayer, and design entwine. My life is rooted in Christ,
-        yet open to the echoes of wisdom scattered through creation. I write and build to trace the outlines of a sacred history: exile and return,
-        death and renewal, ordinary work suffused with the radiance of grace.
+        I&rsquo;m Mark Baldwin-Smith, a pilgrim of words, symbols, and sacrament&mdash;walking a path where poetry, prayer, and design entwine. My life is
+        rooted in Christ, yet open to the echoes of wisdom scattered through creation. I write and build to trace the outlines of a sacred history:
+        exile and return, death and renewal, ordinary work suffused with the radiance of grace.
       </p>
       <div class="page-hero__meta">
         <span class="meta-chip"><Icon name="feather-pointed" aria-hidden="true" /> Writer</span>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -20,8 +20,8 @@ const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site) : new URL('
       <p class="kicker">Contact</p>
       <h1>Connect with me</h1>
       <p class="lead">
-        I welcome conversations about collaborative ministry, data storytelling for the Church, and prayer requests from fellow
-        pilgrims. Send a note if you sense a partnership, need a listening ear, or would like me to speak with your community.
+        I&rsquo;m Mark Baldwin-Smith, and I welcome conversations about collaborative ministry, data storytelling for the Church, and prayer requests from
+        fellow pilgrims. Send a note if you sense a partnership, need a listening ear, or would like me to speak with your community.
       </p>
       <div class="page-hero__meta">
         <span class="meta-chip"><Icon name="comments" aria-hidden="true" /> Collaboration</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site) : new URL('
         <p class="lead">
           This library gathers the prayers, poems, essays, and experiments that have accompanied my pilgrimage of faith.
           Wander through these rooms at your leisure; each one is prepared with care for thoughtful companions and fellow
-          seekers.
+          seekers. Curated by Mark Baldwin-Smith, Kerygma Academy exists to serve your discipleship with beauty and clarity.
         </p>
         <div class="page-hero__meta">
           <span class="meta-chip"><Icon name="book-open" aria-hidden="true" /> Prayerbook</span>


### PR DESCRIPTION
## Summary
- update the site header branding to display Kerygma Academy
- mention Mark Baldwin-Smith in the Home, About, and Contact page introductions

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68f50d0322e483309d56250331e693bb