### PR TITLE
Use small caps for header brand text

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -98,7 +98,7 @@ const isActive = (href: string) => {
     font-family: 'Cormorant Garamond', 'Source Serif 4', serif;
     font-size: clamp(1.4rem, 3vw, 1.9rem);
     letter-spacing: 0.12em;
-    text-transform: uppercase;
+    font-variant: small-caps;
     text-decoration: none;
     color: inherit;
     border: none;


### PR DESCRIPTION
## Summary
- switch the Kerygma Academy brand styling to use typographic small caps instead of all caps

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f51136f6848330afc0cca031d2a326