### PR TITLE
Fix: Kerygma Codex link/title and Essays & Theology link

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,15 +214,15 @@
 
           <!-- Card 3 — The Kerygma Codex -->
           <article class="project-card reveal-on-scroll card-stagger-delay-3">
-            <a href="https://substack.com/@markbaldwinsmith" class="project-card__link-wrapper" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/mbaldwinsmith/kerygma_codex" class="project-card__link-wrapper" target="_blank" rel="noopener noreferrer">
               <figure class="project-card__image-figure">
                 <img class="project-card__image"
                      src="images/works/kerygma-codex-card.png"
-                     alt="The Kerygma Codex — theological writing"
+                     alt="Kerygma Codex — theological writing"
                      loading="lazy"
                      width="800" height="500">
               </figure>
-              <h3 class="project-card__title">The Kerygma Codex</h3>
+              <h3 class="project-card__title">Kerygma Codex</h3>
               <p class="project-card__description">A gentle, trauma-aware Christian grammar for spiritual healing, formation, and coherence repair.</p>
               <span class="project-card__link-hint">Visit <span aria-hidden="true">→</span></span>
             </a>
@@ -246,7 +246,7 @@
 
           <!-- Card 5 — Essays & Theology -->
           <article class="project-card reveal-on-scroll card-stagger-delay-5">
-            <a href="#" class="project-card__link-wrapper" target="_blank" rel="noopener noreferrer">
+            <a href="https://substack.com/@markbaldwinsmith" class="project-card__link-wrapper" target="_blank" rel="noopener noreferrer">
               <figure class="project-card__image-figure">
                 <img class="project-card__image"
                      src="images/works/essays-theology-card.png"


### PR DESCRIPTION
## Summary

- **Kerygma Codex** — link updated to `github.com/mbaldwinsmith/kerygma_codex`; "The" removed from title
- **Essays & Theology** — link updated to `substack.com/@markbaldwinsmith`

🤖 Generated with [Claude Code](https://claude.com/claude-code)