### PR TITLE
Fix: hero flash, ornament mirror, and contact links

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -41,7 +41,7 @@
 }
 
 .animation-hero-text-rise {
-  animation: hero-text-rise 1.5s ease-out 2.8s both;
+  animation: hero-text-rise 1.5s ease-out both; /* timing controlled by hero-animation.js */
 }
 
 .animation-wax-seal-breathe {

--- a/css/hero.css
+++ b/css/hero.css
@@ -51,11 +51,13 @@ header.site-hero {
 /* Name block — top of hero, above the illustration */
 .site-hero__content--name {
   padding-bottom: var(--space-sm);
+  opacity:        0; /* animated in by hero-animation.js */
 }
 
 /* Epithet block — bottom of hero, below the illustration */
 .site-hero__content--epithet {
   padding-top: var(--space-sm);
+  opacity:     0; /* animated in by hero-animation.js */
 }
 
 /* ── Site name heading ── */
@@ -133,7 +135,7 @@ header.site-hero {
 
 .site-hero__corner-ornament--top-left     { top: var(--space-lg);    left:  var(--space-lg);  }
 .site-hero__corner-ornament--top-right    { top: var(--space-lg);    right: var(--space-lg);  }
-.site-hero__corner-ornament--bottom-left  { bottom: var(--space-lg); left:  var(--space-lg);  }
+.site-hero__corner-ornament--bottom-left  { bottom: var(--space-lg); left:  var(--space-lg);  transform: scaleX(-1); }
 .site-hero__corner-ornament--bottom-right { bottom: var(--space-lg); right: var(--space-lg);  }
 
 /* ── Scroll hint at bottom of hero ── */

--- a/index.html
+++ b/index.html
@@ -298,10 +298,8 @@
         </p>
 
         <nav class="contact-section__links-row reveal-on-scroll" aria-label="Contact and social links">
-          <!-- [MARK — CONTENT] Replace all placeholder hrefs with your real URLs -->
-          <a href="mailto:your@email.com" class="contact-link">Post a Letter</a>
-          <a href="#" class="contact-link" target="_blank" rel="noopener noreferrer">Substack</a>
-          <a href="#" class="contact-link" target="_blank" rel="noopener noreferrer">Bandcamp</a>
+          <a href="mailto:mb110413@gmail.com" class="contact-link">Post a Letter</a>
+          <a href="https://substack.com/@markbaldwinsmith" class="contact-link" target="_blank" rel="noopener noreferrer">Substack</a>
           <a href="https://github.com/mbaldwinsmith" class="contact-link" target="_blank" rel="noopener noreferrer">GitHub</a>
         </nav>
 

--- a/js/hero-animation.js
+++ b/js/hero-animation.js
@@ -3,33 +3,44 @@
 // Skips delays entirely when the user has requested reduced motion.
 
 const HERO_ILLUSTRATION_SELECTOR = '.site-hero__central-illustration';
-const HERO_CONTENT_SELECTOR      = '.site-hero__content';
+const HERO_NAME_SELECTOR         = '.site-hero__content--name';
+const HERO_EPITHET_SELECTOR      = '.site-hero__content--epithet';
 const HERO_SCROLL_HINT_SELECTOR  = '.site-hero__scroll-hint';
 
 function beginHeroEntranceSequence() {
   const heroIllustration = document.querySelector(HERO_ILLUSTRATION_SELECTOR);
-  const heroContent      = document.querySelector(HERO_CONTENT_SELECTOR);
+  const heroName         = document.querySelector(HERO_NAME_SELECTOR);
+  const heroEpithet      = document.querySelector(HERO_EPITHET_SELECTOR);
   const heroScrollHint   = document.querySelector(HERO_SCROLL_HINT_SELECTOR);
 
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (prefersReducedMotion) {
-    // Show all elements immediately without delay
     if (heroIllustration) heroIllustration.style.opacity = '1';
-    if (heroContent)      heroContent.style.opacity      = '1';
+    if (heroName)         heroName.style.opacity         = '1';
+    if (heroEpithet)      heroEpithet.style.opacity      = '1';
     if (heroScrollHint)   heroScrollHint.classList.add('animation-scroll-hint-pulse');
     return;
   }
 
+  // Illustration emerges first
   if (heroIllustration) {
     setTimeout(() => {
       heroIllustration.classList.add('animation-hero-emerge');
     }, 400);
   }
 
-  if (heroContent) {
+  // Name rises while illustration is still fading in
+  if (heroName) {
     setTimeout(() => {
-      heroContent.classList.add('animation-hero-text-rise');
+      heroName.classList.add('animation-hero-text-rise');
+    }, 800);
+  }
+
+  // Epithet follows once illustration is mostly visible
+  if (heroEpithet) {
+    setTimeout(() => {
+      heroEpithet.classList.add('animation-hero-text-rise');
     }, 1800);
   }
 


### PR DESCRIPTION
## Summary

### Hero animation flash (root cause fixed)
After the Phase 4 hero restructure, `.site-hero__content` was split into `--name` and `--epithet` modifier classes — but `hero-animation.js` still targeted the old selector. Nothing was ever animated, leaving both text blocks permanently visible, so they appeared instantly rather than fading in.

Changes:
- `hero.css` — set `opacity: 0` on both content blocks so text is hidden before JS fires
- `animations.css` — remove baked-in `2.8s` CSS delay from `.animation-hero-text-rise`; JS now owns all timing
- `hero-animation.js` — update selectors to `.site-hero__content--name` (fades in at 800ms) and `.site-hero__content--epithet` (1800ms); fix reduced-motion path to show both elements immediately

### Sequence after fix
| ms | Event |
|---|---|
| 400 | Illustration begins emerging |
| 800 | Name rises in |
| 1800 | Epithet + motto rise in |
| 4000 | Scroll hint pulses |

### Corner ornament
- Bottom-left `❧` mirrored with `transform: scaleX(-1)` so it faces inward symmetrically

### Contact links
- **Post a Letter** → `mailto:mb110413@gmail.com`
- **Substack** → `substack.com/@markbaldwinsmith`
- **Bandcamp** removed
- **GitHub** → `github.com/mbaldwinsmith`

🤖 Generated with [Claude Code](https://claude.com/claude-code)