### PR TITLE
Update motto, bio text, and card image display

### DIFF
--- a/css/project-cards.css
+++ b/css/project-cards.css
@@ -69,10 +69,9 @@
 }
 
 .project-card__image {
-  width:        100%;
-  aspect-ratio: 16 / 9;
-  object-fit:   cover;
-  display:      block;
+  width:         100%;
+  height:        auto;
+  display:       block;
   border-bottom: 1px solid var(--colour-vellum-crease);
 }
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     <div class="site-hero__content site-hero__content--epithet">
       <p class="site-hero__epithet">Poet · Theologian · Songwriter · Contemplative</p>
       <!-- [MARK — CONTENT] Replace motto with your preferred Latin or English phrase -->
-      <p class="site-hero__motto"><em>per ardua ad lucem</em></p>
+      <p class="site-hero__motto"><em>Via Crucis, Via Lucis</em></p>
     </div>
 
     <!-- Scroll hint -->
@@ -122,17 +122,11 @@
 
           <!-- Main text -->
           <div class="biography-section__text-column">
-            <!-- [MARK — CONTENT] Replace with your first bio paragraph. It will receive the drop cap. -->
             <p class="biography-section__paragraph biography-section__paragraph--with-drop-cap">
-              Placeholder first paragraph. Replace this with your own words — who you are, your faith tradition, and what draws you to the work you do. This paragraph receives the large crimson drop cap.
+              Mark Baldwin-Smith is a poet, coder, and creative artist living in Cambridge, UK, with a lifelong fascination with theology, philosophy, and science, particularly in the contested territory where they illuminate each other's blind spots.
             </p>
-            <!-- [MARK — CONTENT] Replace with your second bio paragraph -->
             <p class="biography-section__paragraph">
-              Placeholder second paragraph. Describe your creative work here — the Golden Thread album, the poetry chapbook, the Kerygma Codex, your Substack. What does each piece of work mean to you?
-            </p>
-            <!-- [MARK — CONTENT] Replace with your third bio paragraph (optional) -->
-            <p class="biography-section__paragraph">
-              Placeholder third paragraph. Your location, your way of life — Cambridge, boxing, Tai Chi, the rhythms of prayer. An invitation to the reader: what does this site offer them?
+              Mark is a Christian of the Anglo-Catholic tradition, rooted in the community of Little St Mary's in Cambridge, with a deep love of contemplative prayer shaped by Carmelite, Hesychast, and Zen influences. While his faith is Trinitarian and Christ-centred, he is a student of humanity in all its wondrous varieties, and encounters the divine in beauty, love, and community wherever he finds it.
             </p>
           </div>
 
@@ -321,7 +315,7 @@
     <div class="site-footer__content">
       <p class="site-footer__name-line">Mark Baldwin-Smith</p>
       <!-- [MARK — CONTENT] Replace motto if changed in hero above -->
-      <p class="site-footer__motto"><em>per ardua ad lucem</em></p>
+      <p class="site-footer__motto"><em>Via Crucis, Via Lucis</em></p>
       <p class="site-footer__made-line">Made with ink &amp; intention · England</p>
       <p class="site-footer__copyright">
         <small>&copy; <span id="footer-current-year"></span> Mark Baldwin-Smith. All rights reserved.</small>


### PR DESCRIPTION
## Summary

- **Motto** — *per ardua ad lucem* → *Via Crucis, Via Lucis* in both hero and footer
- **Bio** — placeholder paragraphs replaced with real text (two paragraphs, drop cap on first)
- **Card images** — removed `aspect-ratio: 16/9` and `object-fit: cover`; images now display at full natural dimensions without cropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)