### PR TITLE
Polish and content: favicon, lang, sitemap, noscript, noise texture, bio, contact

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
   <title>Page not found — Mark Baldwin-Smith</title>
 
   <!-- Google Fonts -->

--- a/css/hero.css
+++ b/css/hero.css
@@ -13,6 +13,17 @@ header.site-hero {
   padding:         var(--space-xl) var(--space-lg) calc(var(--space-xl) + 56px); /* bottom clears scroll hint */
 }
 
+/* Organic grain overlay using the SVG noise filter defined in index.html */
+header.site-hero::after {
+  content:        '';
+  position:       absolute;
+  inset:          0;
+  pointer-events: none;
+  z-index:        4;
+  opacity:        0.035;
+  filter:         url(#vellum-noise-filter);
+}
+
 /* ── Background vellum texture image (low opacity overlay) ── */
 .site-hero__background-image {
   position:   absolute;

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#F2E8D0"/>
+  <text x="16" y="25" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#8B1A1A">❧</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -41,6 +41,11 @@
   <link rel="stylesheet" href="css/animations.css">
   <link rel="stylesheet" href="css/utilities.css">
   <link rel="stylesheet" href="css/print.css" media="print">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <noscript><style>
+    .site-hero__content--name,
+    .site-hero__content--epithet { opacity: 1 !important; }
+  </style></noscript>
 </head>
 <body>
 
@@ -130,6 +135,9 @@
             </p>
             <p class="biography-section__paragraph">
               Mark is a Christian of the Anglo-Catholic tradition, rooted in the community of Little St Mary's in Cambridge, with a deep love of contemplative prayer shaped by Carmelite, Hesychast, and Zen influences. While his faith is Trinitarian and Christ-centred, he is a student of humanity in all its wondrous varieties, and encounters the divine in beauty, love, and community wherever he finds it.
+            </p>
+            <p class="biography-section__paragraph">
+              Here you will find the fruits of that long conversation — poems, theological essays, musical work, and occasional strange syntheses of all three. Offered freely, in the hope that something might be of use to a fellow traveller.
             </p>
           </div>
 
@@ -353,10 +361,9 @@
           <div class="section-dividing-rule" aria-hidden="true"></div>
         </div>
 
-        <!-- [MARK — CONTENT] Replace with your own warm, personal invitation to connect -->
         <p class="contact-section__intro-text reveal-on-scroll">
-          Letters, commissions, and theological conversation are welcome.<br>
-          I am found in the usual places.
+          If something here has moved you, or if you wish to discuss theology,<br>
+          commission a piece, or simply correspond — I would be glad to hear from you.
         </p>
 
         <nav class="contact-section__links-row reveal-on-scroll" aria-label="Contact and social links">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /404.html
+
+Sitemap: https://mbaldwinsmith.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mbaldwinsmith.github.io/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Seven improvements in one PR:

| # | What | Detail |
|---|---|---|
| 1 | **Favicon** | `favicon.svg` — crimson ❧ on vellum `#F2E8D0`; linked in `index.html` and `404.html` |
| 2 | **`lang="en-GB"`** | Corrected from `en` in both HTML files — affects hyphenation, spell-check, screen readers |
| 3 | **`robots.txt` + `sitemap.xml`** | Allows all crawlers, disallows `404.html`, points to sitemap; sitemap lists the canonical index URL |
| 4 | **`<noscript>` fallback** | If JS is blocked/fails, hero name and epithet are forced to `opacity: 1` so the page isn't blank |
| 5 | **Vellum noise overlay** | `header.site-hero::after` applies the inline SVG `feTurbulence` filter at `0.035` opacity — adds organic grain texture to the hero distinct from the CSS grain lines on `body::before` |
| 6 | **Third bio paragraph** | Invitation / closing hook: *"Here you will find the fruits of that long conversation…"* |
| 7 | **Contact intro text** | Replaced generic placeholder with personal voice: *"If something here has moved you…"* |

## Test plan
- [ ] Browser tab shows crimson ❧ favicon
- [ ] `robots.txt` and `sitemap.xml` load at their root paths
- [ ] Disable JS in devtools → hero name and epithet visible immediately
- [ ] Hero has a faint organic grain texture distinct from page background
- [ ] Bio section now has three paragraphs, third is the invitation
- [ ] Contact intro reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)