### PR TITLE
Content polish: Julian of Norwich, Golden Thread link, image dimensions, remove comments

### DIFF
--- a/404.html
+++ b/404.html
@@ -101,7 +101,7 @@
       <img class="error-page__ornament"
            src="images/decorative/colophon-ornament.png"
            alt=""
-           width="600" height="200">
+           width="1254" height="1254">
     </figure>
 
     <p class="error-page__divider" aria-hidden="true">✦ ✦ ✦</p>

--- a/css/featured-poem.css
+++ b/css/featured-poem.css
@@ -64,6 +64,33 @@
   padding-top:     var(--space-md);
 }
 
+/* ── Collection link ── */
+.featured-poem__collection-link {
+  text-align:  right;
+  margin-top:  var(--space-sm);
+}
+
+.featured-poem__collection-link a {
+  font-family:     var(--font-family-fell-pica);
+  font-style:      italic;
+  font-size:       var(--font-size-small);
+  color:           var(--colour-crimson);
+  text-decoration: none;
+  letter-spacing:  var(--letter-spacing-wide);
+  border-bottom:   1px solid transparent;
+  transition:      color var(--transition-hover), border-color var(--transition-hover);
+}
+
+.featured-poem__collection-link a:hover {
+  color:        var(--colour-crimson-bright);
+  border-color: var(--colour-crimson-bright);
+}
+
+.featured-poem__collection-link a:focus-visible {
+  outline:        2px solid var(--colour-crimson);
+  outline-offset: 3px;
+}
+
 /* ── Responsive: single column on small screens ── */
 @media (max-width: 768px) {
   .featured-poem__layout {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- [MARK — CONTENT] Replace with your 1–2 sentence site description -->
   <meta name="description" content="Mark Baldwin-Smith — poet, theologian, coder, and contemplative. Music, writing, and devotional life rooted in the Anglo-Catholic tradition.">
 
   <!-- Open Graph -->
@@ -66,7 +65,7 @@
          src="images/hero/vellum-texture-bg.png"
          alt=""
          aria-hidden="true"
-         width="1920" height="1080">
+         width="1672" height="941">
 
     <!-- Corner ornaments — IM Fell typographic symbols in crimson -->
     <span class="site-hero__corner-ornament site-hero__corner-ornament--top-left"     aria-hidden="true">✦</span>
@@ -86,13 +85,12 @@
       <img class="site-hero__central-illustration"
            src="images/hero/pilgrim-tree.png"
            alt=""
-           width="640" height="427">
+           width="1672" height="941">
     </figure>
 
     <!-- Epithet and motto — sits below the illustration -->
     <div class="site-hero__content site-hero__content--epithet">
       <p class="site-hero__epithet">Poet · Theologian · Coder · Contemplative</p>
-      <!-- [MARK — CONTENT] Replace motto with your preferred Latin or English phrase -->
       <p class="site-hero__motto"><em>Via Crucis, Via Lucis</em></p>
     </div>
 
@@ -137,7 +135,7 @@
               Mark is a Christian of the Anglo-Catholic tradition, rooted in the community of Little St Mary's in Cambridge, with a deep love of contemplative prayer shaped by Carmelite, Hesychast, and Zen influences. While his faith is Trinitarian and Christ-centred, he is a student of humanity in all its wondrous varieties, and encounters the divine in beauty, love, and community wherever he finds it.
             </p>
             <p class="biography-section__paragraph">
-              Here you will find the fruits of that long conversation — poems, theological essays, coding, and occasional syntheses of all three. Offered freely, in the hope that something might be of use to a fellow pilgrim.
+              Here you will find the fruits of that long conversation: poems, theological essays, coding, and occasional syntheses of all three. Offered freely, in the hope that something might be of use to a fellow pilgrim.
             </p>
           </div>
 
@@ -146,8 +144,7 @@
             <img class="biography-section__wax-seal-image animation-wax-seal-breathe"
                  src="images/decorative/wax-seal.png"
                  alt="Wax seal monogram M.B.S."
-                 width="120" height="120">
-            <!-- [MARK — CONTENT] Replace with quotes more personally significant to you -->
+                 width="1254" height="1254">
             <blockquote class="biography-section__pull-quote">
               "Beauty will save the world."
               <cite>— Dostoevsky</cite>
@@ -156,6 +153,11 @@
             <blockquote class="biography-section__pull-quote">
               "The soul is that which can be touched by Being."
               <cite>— Rowan Williams</cite>
+            </blockquote>
+            <div class="ornament-divider" aria-hidden="true">✦ ✦ ✦</div>
+            <blockquote class="biography-section__pull-quote">
+              "All shall be well, and all shall be well, and all manner of thing shall be well."
+              <cite>— Julian of Norwich</cite>
             </blockquote>
           </aside>
 
@@ -170,7 +172,7 @@
            alt=""
            class="folio-ornament-image"
            loading="lazy"
-           width="900" height="300">
+           width="1824" height="862">
     </figure>
 
     <!-- ══ FEATURED POEM ══ -->
@@ -191,7 +193,7 @@
                  src="images/works/sweet-sophia-card.png"
                  alt="Sweet Sophia, Holy Hokhmah — an illuminated illustration"
                  loading="lazy"
-                 width="800" height="500">
+                 width="1024" height="1536">
           </figure>
 
           <div class="featured-poem__verse reveal-on-scroll">
@@ -232,6 +234,9 @@
               In eternal love, a garden of many flowers.
             </p>
             <p class="featured-poem__attribution">— Mark Baldwin-Smith</p>
+            <p class="featured-poem__collection-link">
+              <a href="https://mbaldwinsmith.github.io/the_golden_thread/" target="_blank" rel="noopener noreferrer">Read the full collection →</a>
+            </p>
           </div>
 
         </div>
@@ -258,7 +263,7 @@
                      src="images/decorative/manuscript-portrait.png"
                      alt="Portrait of Mark Baldwin-Smith"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1536" height="1024">
               </figure>
               <h3 class="project-card__title">About Me</h3>
               <p class="project-card__description">Professional profile and creative practice — theologian, poet, and contemplative practitioner.</p>
@@ -274,7 +279,7 @@
                      src="images/works/golden-thread-card.png"
                      alt="The Golden Thread — thirteen poems"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1536" height="1024">
               </figure>
               <h3 class="project-card__title">The Golden Thread</h3>
               <p class="project-card__description">Thirteen poems. One journey. Follow the thread.</p>
@@ -290,7 +295,7 @@
                      src="images/works/kerygma-codex-card.png"
                      alt="Kerygma Codex — theological writing"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1448" height="1086">
               </figure>
               <h3 class="project-card__title">Kerygma Codex</h3>
               <p class="project-card__description">A gentle, trauma-aware Christian grammar for spiritual healing, formation, and coherence repair.</p>
@@ -306,7 +311,7 @@
                      src="images/works/poetry-chapbook-card.png"
                      alt="Aurum Cordis — the Opus Magnum as Christian Way"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1536" height="1024">
               </figure>
               <h3 class="project-card__title">Aurum Cordis</h3>
               <p class="project-card__description">The Opus Magnum as Christian Way: Alchemy, Theology, and the Soul's Transformation.</p>
@@ -322,7 +327,7 @@
                      src="images/works/essays-theology-card.png"
                      alt="Essays and Theology — Substack writings"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1536" height="1024">
               </figure>
               <h3 class="project-card__title">Essays &amp; Theology</h3>
               <p class="project-card__description">Theological essays published on Substack. On scripture, liturgy, mysticism, and the life of prayer in the Anglican Catholic tradition.</p>
@@ -332,13 +337,13 @@
 
           <!-- Card 6 — Lifelong Pilgrimage -->
           <article class="project-card reveal-on-scroll card-stagger-delay-6">
-            <a href="#" class="project-card__link-wrapper" target="_blank" rel="noopener noreferrer">
+            <a href="#" class="project-card__link-wrapper">
               <figure class="project-card__image-figure">
                 <img class="project-card__image"
                      src="images/works/community-vision-card.png"
                      alt="Lifelong Pilgrimage — contemplative community and the Walsingham tradition"
                      loading="lazy"
-                     width="800" height="500">
+                     width="1536" height="1024">
               </figure>
               <h3 class="project-card__title">Lifelong Pilgrimage</h3>
               <p class="project-card__description">A vision for contemplative community rooted in the Walsingham tradition — a place of pilgrimage, prayer, and the common life.</p>
@@ -377,7 +382,7 @@
                alt=""
                class="colophon-ornament-image"
                loading="lazy"
-               width="600" height="200">
+               width="1254" height="1254">
         </figure>
 
       </div>
@@ -389,7 +394,6 @@
   <footer class="site-footer">
     <div class="site-footer__content">
       <p class="site-footer__name-line">Mark Baldwin-Smith</p>
-      <!-- [MARK — CONTENT] Replace motto if changed in hero above -->
       <p class="site-footer__motto"><em>Via Crucis, Via Lucis</em></p>
       <p class="site-footer__made-line">Made with ink &amp; intention · England</p>
       <p class="site-footer__copyright">


### PR DESCRIPTION
## Summary

- **Third pull-quote**: Julian of Norwich — *"All shall be well, and all shall be well, and all manner of thing shall be well."* — added to biography aside with ornament divider
- **Golden Thread link**: *"Read the full collection →"* link added after poem attribution in the Verse section, styled in crimson italic
- **Lifelong Pilgrimage**: removed `target="_blank" rel="noopener noreferrer"` from `href="#"` card (no live URL yet)
- **Stale comments removed**: all four `[MARK — CONTENT]` HTML comments stripped from meta description, hero motto, aside quotes, and footer motto
- **Image dimensions fixed**: all `width`/`height` attributes updated to match actual pixel dimensions (prevents CLS layout shift):
  - `pilgrim-tree.png` 1672×941 (was 640×427)
  - `vellum-texture-bg.png` 1672×941 (was 1920×1080)
  - `folio-ornament-works.png` 1824×862 (was 900×300)
  - `sweet-sophia-card.png` 1024×1536 portrait (was 800×500 landscape)
  - `kerygma-codex-card.png` 1448×1086 (was 800×500)
  - `colophon-ornament.png` 1254×1254 square (was 600×200) — fixed in both index.html and 404.html
  - All six card images updated to their correct 1536×1024 or actual dimensions

## Test plan

- [ ] Verse section shows "Read the full collection →" link after attribution, linking to The Golden Thread
- [ ] Biography aside shows three pull-quotes: Dostoevsky, Rowan Williams, Julian of Norwich
- [ ] Lifelong Pilgrimage card does not open a new tab when clicked
- [ ] No `[MARK — CONTENT]` comments visible in page source
- [ ] No layout shift on page load (image dimensions correct)
- [ ] Sweet Sophia image renders as portrait orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)