### PR TITLE
CSS animations: skeleton shimmer, section rule draw, card image zoom

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -34,6 +34,11 @@
   50%       { opacity: 1;   transform: scaleY(1.15); }
 }
 
+@keyframes skeleton-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
 /* ── Animation utility classes ── */
 
 .animation-hero-emerge {

--- a/css/featured-poem.css
+++ b/css/featured-poem.css
@@ -15,7 +15,12 @@
 
 /* ── Illustration ── */
 .featured-poem__image-figure {
-  margin: 0;
+  margin:           0;
+  overflow:         hidden;
+  background-color: var(--colour-vellum-crease);
+  background-image: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%);
+  background-size:  200% 100%;
+  animation:        skeleton-shimmer 1.8s ease-in-out infinite;
 }
 
 .featured-poem__image {

--- a/css/layout.css
+++ b/css/layout.css
@@ -35,6 +35,13 @@
   height:           1px;
   background-color: var(--colour-ink);
   opacity:          0.35;
+  transform:        scaleX(0);
+  transform-origin: center;
+  transition:       transform 0.7s ease-out 0.2s;
+}
+
+.section-header-row.is-visible .section-dividing-rule {
+  transform: scaleX(1);
 }
 
 /* ── Full-width rule between sections ── */

--- a/css/project-cards.css
+++ b/css/project-cards.css
@@ -77,6 +77,11 @@
   height:        auto;
   display:       block;
   border-bottom: 1px solid var(--colour-vellum-crease);
+  transition:    transform 0.5s ease;
+}
+
+.project-card:hover .project-card__image {
+  transform: scale(1.04);
 }
 
 .project-card__symbol {

--- a/css/project-cards.css
+++ b/css/project-cards.css
@@ -64,8 +64,12 @@
 
 /* ── Card elements ── */
 .project-card__image-figure {
-  margin-bottom: var(--space-md);
-  overflow:      hidden;
+  margin-bottom:    var(--space-md);
+  overflow:         hidden;
+  background-color: var(--colour-vellum-crease);
+  background-image: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%);
+  background-size:  200% 100%;
+  animation:        skeleton-shimmer 1.8s ease-in-out infinite;
 }
 
 .project-card__image {


### PR DESCRIPTION
## Summary

Three progressive-enhancement animations, all respecting `prefers-reduced-motion` via the blanket rule in `animations.css`.

- **Skeleton shimmer** (`animations.css`, `project-cards.css`, `featured-poem.css`) — warm-cream gradient sweeps across each image figure while the image loads. Works because `width`/`height` attributes are set to actual pixel dimensions, so the browser reserves correctly-proportioned space before the image arrives.
- **Section rule draw** (`layout.css`) — the crimson-tinted ink lines flanking each `<h2>` animate `scaleX(0 → 1)` from centre when the header row scrolls into view. A 0.2s delay lets the heading fade in first, then the lines draw outward like a scribe ruling the page.
- **Card image zoom** (`project-cards.css`) — card images scale up 4% on hover inside the existing `overflow: hidden` figure, giving depth without disturbing the card frame.

## Test plan

- [ ] On a throttled connection, image placeholders show a warm shimmer in the correct aspect ratio before each image loads
- [ ] Section headings: after scroll reveal, the flanking rules draw outward from centre
- [ ] Hovering a works card zooms the image within the card frame — no overflow or clipping visible
- [ ] With `prefers-reduced-motion: reduce` in OS settings, all three effects are instant / static

🤖 Generated with [Claude Code](https://claude.com/claude-code)