### PR TITLE
Fix nav skipping Works section on scroll

### DIFF
--- a/js/navigation-behaviour.js
+++ b/js/navigation-behaviour.js
@@ -1,6 +1,5 @@
 // navigation-behaviour.js
-// Watches each page section with IntersectionObserver and highlights the matching nav link
-// when that section occupies more than 50% of the viewport.
+// Watches scroll position and highlights the nav link for the active page section.
 
 const NAVIGATION_ELEMENT_SELECTOR = 'nav.site-navigation';
 const NAVIGATION_LINK_SELECTOR    = '.site-navigation__link';
@@ -9,30 +8,36 @@ const ACTIVE_LINK_CLASS           = 'is-active';
 function applyActiveLinkHighlight() {
   const navigationElement      = document.querySelector(NAVIGATION_ELEMENT_SELECTOR);
   const navigationLinkElements = document.querySelectorAll(NAVIGATION_LINK_SELECTOR);
-  const sectionElements        = document.querySelectorAll('main section[id], header[id]');
+  const sectionElements        = Array.from(document.querySelectorAll('main section[id], header[id]'));
 
   if (!navigationElement || navigationLinkElements.length === 0) return;
 
-  const activeSectionObserver = new IntersectionObserver(handleSectionIntersection, {
-    threshold: 0.5
-  });
+  function updateActiveLink() {
+    // The active section is the last one whose top edge is above 40% of the viewport.
+    // Using getBoundingClientRect works correctly for sections of any height.
+    const threshold = window.innerHeight * 0.4;
+    let activeSection = null;
 
-  sectionElements.forEach(section => activeSectionObserver.observe(section));
+    for (const section of sectionElements) {
+      if (section.getBoundingClientRect().top <= threshold) {
+        activeSection = section;
+      }
+    }
 
-  function handleSectionIntersection(intersectionEntries) {
-    intersectionEntries.forEach(entry => {
-      if (!entry.isIntersecting) return;
+    if (!activeSection) return;
 
-      const matchingLink = document.querySelector(
-        `${NAVIGATION_LINK_SELECTOR}[href="#${entry.target.id}"]`
-      );
+    const matchingLink = document.querySelector(
+      `${NAVIGATION_LINK_SELECTOR}[href="#${activeSection.id}"]`
+    );
 
-      if (!matchingLink) return;
+    if (!matchingLink) return;
 
-      navigationLinkElements.forEach(link => link.classList.remove(ACTIVE_LINK_CLASS));
-      matchingLink.classList.add(ACTIVE_LINK_CLASS);
-    });
+    navigationLinkElements.forEach(link => link.classList.remove(ACTIVE_LINK_CLASS));
+    matchingLink.classList.add(ACTIVE_LINK_CLASS);
   }
+
+  window.addEventListener('scroll', updateActiveLink, { passive: true });
+  updateActiveLink();
 }
 
 // Marginal notes are shown on :hover in CSS; this extends that to keyboard focus


### PR DESCRIPTION
IntersectionObserver with threshold:0.5 can never fire for sections taller
than 2× the viewport (intersection ratio is capped at viewport/section height).
Replace with a scroll listener that marks the last section whose top edge has
passed 40% of the viewport as active — correct for sections of any height.

https://claude.ai/code/session_012N69KkWCDC8rVnfxMdrqmY