### PR TITLE
Add Pilgrim Tools page and update Works card

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,18 +335,18 @@
             </a>
           </article>
 
-          <!-- Card 6 — Lifelong Pilgrimage -->
+          <!-- Card 6 — Pilgrim Tools -->
           <article class="project-card reveal-on-scroll card-stagger-delay-6">
-            <a href="#" class="project-card__link-wrapper">
+            <a href="/tools.html" class="project-card__link-wrapper">
               <figure class="project-card__image-figure">
                 <img class="project-card__image"
                      src="images/works/community-vision-card.png"
-                     alt="Lifelong Pilgrimage — contemplative community and the Walsingham tradition"
+                     alt="Pilgrim Tools — devotional aids for the journey of prayer"
                      loading="lazy"
                      width="1536" height="1024">
               </figure>
-              <h3 class="project-card__title">Lifelong Pilgrimage</h3>
-              <p class="project-card__description">A vision for contemplative community rooted in the Walsingham tradition — a place of pilgrimage, prayer, and the common life.</p>
+              <h3 class="project-card__title">Pilgrim Tools</h3>
+              <p class="project-card__description">Devotional aids for the journey of prayer — consecration prayers, the Angelus, Anglican novenas, and a rule of life.</p>
               <span class="project-card__link-hint">Visit <span aria-hidden="true">→</span></span>
             </a>
           </article>

--- a/tools.html
+++ b/tools.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Pilgrim Tools — devotional aids for the journey of prayer. Consecration prayers, the Angelus, Anglican novenas, and a rule of life.">
+
+  <!-- Open Graph -->
+  <meta property="og:title"       content="Pilgrim Tools — Mark Baldwin-Smith">
+  <meta property="og:description" content="Devotional aids for the journey of prayer.">
+  <meta property="og:image"       content="images/works/community-vision-card.png">
+  <meta property="og:type"        content="website">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card"        content="summary_large_image">
+  <meta name="twitter:title"       content="Pilgrim Tools — Mark Baldwin-Smith">
+  <meta name="twitter:description" content="Devotional aids for the journey of prayer.">
+  <meta name="twitter:image"       content="images/works/community-vision-card.png">
+
+  <title>Pilgrim Tools — Mark Baldwin-Smith</title>
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&family=IM+Fell+DW+Pica:ital@0;1&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet">
+
+  <!-- Stylesheets -->
+  <link rel="stylesheet" href="css/variables.css">
+  <link rel="stylesheet" href="css/base.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/navigation.css">
+  <link rel="stylesheet" href="css/project-cards.css">
+  <link rel="stylesheet" href="css/contact.css">
+  <link rel="stylesheet" href="css/animations.css">
+  <link rel="stylesheet" href="css/utilities.css">
+  <link rel="stylesheet" href="css/print.css" media="print">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+
+  <style>
+    /* ── Pilgrim Tools page — inline scoped styles ── */
+
+    .tools-header {
+      background-color: var(--colour-vellum-shadow);
+      border-bottom:    1px solid var(--colour-vellum-crease);
+      padding:          var(--space-xxl) var(--space-lg) var(--space-xl);
+      text-align:       center;
+    }
+
+    .tools-header__back-link {
+      display:         inline-block;
+      font-family:     var(--font-family-fell-pica);
+      font-style:      italic;
+      font-size:       var(--font-size-small);
+      color:           var(--colour-crimson);
+      text-decoration: none;
+      letter-spacing:  var(--letter-spacing-wide);
+      margin-bottom:   var(--space-lg);
+      transition:      color var(--transition-hover);
+    }
+
+    .tools-header__back-link:hover {
+      color: var(--colour-crimson-bright);
+    }
+
+    .tools-header__ornament {
+      display:      block;
+      font-size:    1.4rem;
+      color:        var(--colour-crimson);
+      margin-bottom: var(--space-sm);
+    }
+
+    .tools-header__title {
+      font-family:    var(--font-family-cinzel);
+      font-size:      var(--font-size-h1);
+      font-weight:    400;
+      color:          var(--colour-ink);
+      letter-spacing: var(--letter-spacing-wide);
+      margin-bottom:  var(--space-sm);
+      line-height:    var(--line-height-heading);
+    }
+
+    .tools-header__subtitle {
+      font-family: var(--font-family-fell-english);
+      font-style:  italic;
+      font-size:   1.1rem;
+      color:       var(--colour-sepia);
+      max-width:   540px;
+      margin:      0 auto;
+      line-height: var(--line-height-body);
+    }
+
+    .tools-section {
+      background-color: var(--colour-vellum);
+      padding:          var(--space-xxl) var(--space-lg);
+    }
+
+    .tools-section__grid {
+      display:               grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap:                   var(--space-lg);
+      max-width:             var(--max-content-width);
+      margin:                0 auto;
+    }
+
+    .tool-card {
+      position:         relative;
+      background-color: rgba(242, 232, 208, 0.6);
+      border:           1px solid var(--colour-ink);
+      padding:          var(--space-xl) var(--space-md) var(--space-lg);
+      text-align:       center;
+      transform:        rotate(var(--tool-card-tilt, 0deg));
+      transition:       transform var(--transition-hover),
+                        box-shadow var(--transition-hover);
+    }
+
+    .tool-card:nth-child(odd)  { --tool-card-tilt:  0.4deg; }
+    .tool-card:nth-child(even) { --tool-card-tilt: -0.4deg; }
+
+    .tool-card::before {
+      content:        '';
+      position:       absolute;
+      inset:          var(--space-xs);
+      border:         1px solid transparent;
+      pointer-events: none;
+      transition:     border-color var(--transition-hover);
+    }
+
+    .tool-card:hover {
+      transform:  rotate(0deg) translateY(-4px);
+      box-shadow: 4px 8px 24px var(--colour-shadow-warm-deep);
+    }
+
+    .tool-card:hover::before {
+      border-color: var(--colour-crimson);
+    }
+
+    .tool-card__link-wrapper {
+      display:         block;
+      text-decoration: none;
+      color:           inherit;
+    }
+
+    .tool-card__link-wrapper:focus-visible {
+      outline:        2px solid var(--colour-crimson);
+      outline-offset: 3px;
+    }
+
+    .tool-card__glyph {
+      display:       block;
+      font-size:     2.2rem;
+      color:         var(--colour-crimson);
+      margin-bottom: var(--space-sm);
+      line-height:   1;
+    }
+
+    .tool-card__title {
+      font-family:   var(--font-family-fell-pica);
+      font-size:     1.2rem;
+      color:         var(--colour-ink);
+      margin-bottom: var(--space-xs);
+      line-height:   var(--line-height-heading);
+    }
+
+    .tool-card__description {
+      font-family:   var(--font-family-fell-english);
+      font-style:    italic;
+      font-size:     var(--font-size-small);
+      color:         var(--colour-sepia);
+      line-height:   var(--line-height-body);
+      margin-bottom: var(--space-sm);
+    }
+
+    .tool-card__link-hint {
+      display:        block;
+      font-family:    var(--font-family-fell-pica);
+      font-size:      var(--font-size-caption);
+      font-style:     italic;
+      color:          var(--colour-crimson);
+      letter-spacing: var(--letter-spacing-wide);
+      opacity:        0;
+      transform:      translateX(-6px);
+      transition:     opacity var(--transition-hover),
+                      transform var(--transition-hover);
+    }
+
+    .tool-card:hover .tool-card__link-hint {
+      opacity:   1;
+      transform: translateX(0);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .tool-card,
+      .tool-card::before,
+      .tool-card__link-hint { transition: none; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- ══ NAVIGATION ══ -->
+  <nav class="site-navigation" aria-label="Main navigation">
+    <a href="/"       class="site-navigation__link">Home</a>
+    <a href="/#about" class="site-navigation__link">About</a>
+    <a href="/#verse" class="site-navigation__link">Verse</a>
+    <a href="/#works" class="site-navigation__link">Works</a>
+  </nav>
+
+  <div class="full-width-rule" aria-hidden="true"></div>
+
+  <!-- ══ PAGE HEADER ══ -->
+  <header class="tools-header">
+    <a href="/" class="tools-header__back-link">← Return to the folio</a>
+    <span class="tools-header__ornament" aria-hidden="true">✦</span>
+    <h1 class="tools-header__title">Pilgrim Tools</h1>
+    <p class="tools-header__subtitle">
+      Aids and companions for the way — prayers, offices, and a rule of life
+      for those who walk toward the light.
+    </p>
+  </header>
+
+  <div class="full-width-rule" aria-hidden="true"></div>
+
+  <main>
+
+    <!-- ══ TOOLS GRID ══ -->
+    <section class="tools-section" aria-label="Pilgrim tools">
+      <div class="tools-section__grid">
+
+        <!-- Consecration -->
+        <article class="tool-card">
+          <a href="/consecration/" class="tool-card__link-wrapper">
+            <span class="tool-card__glyph" aria-hidden="true">✝</span>
+            <h2 class="tool-card__title">Consecration</h2>
+            <p class="tool-card__description">Prayers of self-offering and consecration for daily devotion.</p>
+            <span class="tool-card__link-hint">Open <span aria-hidden="true">→</span></span>
+          </a>
+        </article>
+
+        <!-- Angelus -->
+        <article class="tool-card">
+          <a href="https://angelus.live" class="tool-card__link-wrapper" target="_blank" rel="noopener noreferrer">
+            <span class="tool-card__glyph" aria-hidden="true">☩</span>
+            <h2 class="tool-card__title">Angelus</h2>
+            <p class="tool-card__description">The ancient prayer of the Incarnation, rung at the hours of devotion.</p>
+            <span class="tool-card__link-hint">Visit <span aria-hidden="true">→</span></span>
+          </a>
+        </article>
+
+        <!-- Anglican Novenas -->
+        <article class="tool-card">
+          <a href="/anglican-novenas/" class="tool-card__link-wrapper">
+            <span class="tool-card__glyph" aria-hidden="true">❧</span>
+            <h2 class="tool-card__title">Anglican Novenas</h2>
+            <p class="tool-card__description">Nine-day cycles of prayer in the Anglican Catholic tradition.</p>
+            <span class="tool-card__link-hint">Open <span aria-hidden="true">→</span></span>
+          </a>
+        </article>
+
+        <!-- Regula -->
+        <article class="tool-card">
+          <a href="/regula/" class="tool-card__link-wrapper">
+            <span class="tool-card__glyph" aria-hidden="true">✦</span>
+            <h2 class="tool-card__title">Regula</h2>
+            <p class="tool-card__description">A simple rule of life for the pilgrim who is not yet in a monastery.</p>
+            <span class="tool-card__link-hint">Open <span aria-hidden="true">→</span></span>
+          </a>
+        </article>
+
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ══ FOOTER ══ -->
+  <div class="full-width-rule" aria-hidden="true"></div>
+  <footer class="site-footer">
+    <div class="site-footer__content">
+      <p class="site-footer__name-line">Mark Baldwin-Smith</p>
+      <p class="site-footer__motto"><em>Via Crucis, Via Lucis</em></p>
+      <p class="site-footer__made-line">Made with ink &amp; intention · England</p>
+      <p class="site-footer__copyright">
+        <small>&copy; <span id="footer-current-year"></span> Mark Baldwin-Smith. All rights reserved.</small>
+      </p>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('footer-current-year').textContent = new Date().getFullYear();
+  </script>
+
+  <script src="js/navigation-behaviour.js" defer></script>
+
+</body>
+</html>


### PR DESCRIPTION
Renames the "Lifelong Pilgrimage" card on the home page to "Pilgrim Tools"
and links it to the new /tools.html sub-page. The tools page lists four
devotional aids: Consecration, Angelus, Anglican Novenas, and Regula.